### PR TITLE
run create projects job on upgrade

### DIFF
--- a/charts/dependabot-gitlab/Chart.yaml
+++ b/charts/dependabot-gitlab/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: dependabot-gitlab
 description: Deployment chart for dependabot-gitlab app
 type: application
-version: 0.0.46
+version: 0.0.47
 appVersion: 0.4.3
 icon: https://gitlab.com/dependabot-gitlab/dependabot/-/raw/master/logo.png
 maintainers:

--- a/charts/dependabot-gitlab/README.md
+++ b/charts/dependabot-gitlab/README.md
@@ -1,6 +1,6 @@
 # dependabot-gitlab
 
-![Version: 0.0.46](https://img.shields.io/badge/Version-0.0.46-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
+![Version: 0.0.47](https://img.shields.io/badge/Version-0.0.47-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
 
 [dependabot-gitlab](https://gitlab.com/dependabot-gitlab/dependabot) is application providing automated dependency management for gitlab projects
 

--- a/charts/dependabot-gitlab/templates/job.yaml
+++ b/charts/dependabot-gitlab/templates/job.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "dependabot-gitlab.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-install
+    helm.sh/hook: post-install,post-upgrade
 spec:
   backoffLimit: 2
   activeDeadlineSeconds: 30


### PR DESCRIPTION
This will run the create-projects-job job when the helm release is upgraded, for example with new projects.