### PR TITLE
Set default passwords for redis and mongodb

### DIFF
--- a/charts/dependabot-gitlab/Chart.yaml
+++ b/charts/dependabot-gitlab/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: dependabot-gitlab
 description: Deployment chart for dependabot-gitlab app
 type: application
-version: 0.0.57
+version: 0.0.58
 appVersion: 0.6.0
 icon: https://gitlab.com/dependabot-gitlab/dependabot/-/raw/master/logo.png
 maintainers:

--- a/charts/dependabot-gitlab/README.md
+++ b/charts/dependabot-gitlab/README.md
@@ -1,6 +1,6 @@
 # dependabot-gitlab
 
-![Version: 0.0.57](https://img.shields.io/badge/Version-0.0.57-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.0.58](https://img.shields.io/badge/Version-0.0.58-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 [dependabot-gitlab](https://gitlab.com/dependabot-gitlab/dependabot) is application providing automated dependency management for gitlab projects
 

--- a/charts/dependabot-gitlab/README.md
+++ b/charts/dependabot-gitlab/README.md
@@ -62,7 +62,7 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | ingress.tls | list | `[]` |  |
 | mongodb.auth.database | string | `"dependabot_gitab"` | MongoDB custom database |
 | mongodb.auth.enabled | bool | `true` | Enable authentication |
-| mongodb.auth.password | string | `""` | MongoDB custom user password |
+| mongodb.auth.password | string | `"mongodb-password"` | MongoDB custom user password |
 | mongodb.auth.rootPassword | string | `""` | MongoDB root password |
 | mongodb.auth.username | string | `"dependabot-gitlab"` | MongoDB custom user username |
 | mongodb.clusterDomain | string | `"cluster.local"` | Kubernetes Cluster Domain |
@@ -74,7 +74,7 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | podAnnotations | object | `{}` | Pod annotations |
 | projects | list | `[]` | List of projects to create/update on deployment |
 | redis.auth.enabled | bool | `true` | Enable authentication |
-| redis.auth.password | string | `""` | Redis password |
+| redis.auth.password | string | `"redis-password"` | Redis password |
 | redis.cluster.enabled | bool | `false` | Enable redis cluster |
 | redis.clusterDomain | string | `"cluster.local"` | Kubernetes Cluster Domain |
 | redis.enabled | bool | `true` | Enable redis installation |

--- a/charts/dependabot-gitlab/values.yaml
+++ b/charts/dependabot-gitlab/values.yaml
@@ -153,7 +153,7 @@ redis:
     # -- Enable authentication
     enabled: true
     # -- Redis password
-    password: ""
+    password: "redis-password"
 
 # ref: https://github.com/bitnami/charts/tree/master/bitnami/mongodb
 mongodb:
@@ -171,7 +171,7 @@ mongodb:
     # -- MongoDB custom user username
     username: "dependabot-gitlab"
     # -- MongoDB custom user password
-    password: ""
+    password: "mongodb-password"
     # -- MongoDB custom database
     database: dependabot_gitab
   service:


### PR DESCRIPTION
Use default passwords to avoid potential issues during upgrades: https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases