### PR TITLE
Make securityContext configurable in values.yaml

### DIFF
--- a/charts/dependabot-gitlab/Chart.yaml
+++ b/charts/dependabot-gitlab/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: dependabot-gitlab
 description: Deployment chart for dependabot-gitlab app
 type: application
-version: 0.0.68
+version: 0.0.69
 appVersion: 0.9.0
 icon: https://gitlab.com/dependabot-gitlab/dependabot/-/raw/master/logo.png
 maintainers:

--- a/charts/dependabot-gitlab/README.md
+++ b/charts/dependabot-gitlab/README.md
@@ -1,6 +1,6 @@
 # dependabot-gitlab
 
-![Version: 0.0.68](https://img.shields.io/badge/Version-0.0.68-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 0.0.69](https://img.shields.io/badge/Version-0.0.69-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 [dependabot-gitlab](https://gitlab.com/dependabot-gitlab/dependabot) is application providing automated dependency management for gitlab projects
 
@@ -74,6 +74,7 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | nameOverride | string | `""` | Override chart name |
 | nodeSelector | object | `{}` | Node selectors |
 | podAnnotations | object | `{}` | Pod annotations |
+| podSecurityContext | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsUser":1000}` | Security Context |
 | project_registration.cron | string | `""` | Cron expression of project registration cron job |
 | project_registration.mode | string | `"manual"` | Project registration mode |
 | project_registration.namespace | string | `""` | Allowed namespace expression for projects to register |
@@ -85,7 +86,6 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | redis.enabled | bool | `true` | Enable redis installation |
 | redis.fullnameOverride | string | `"redis"` | Override redis name |
 | registriesCredentials | object | `{}` | Credentials for private registries: PRIVATE_DOCKERHUB_TOKEN: token |
-| securityContext | object | `{ runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }` | Security context definitions for all started containers|
 | service.annotations | object | `{}` | Service annotations |
 | service.port | int | `3000` | Service pot |
 | service.type | string | `"ClusterIP"` | Service type |

--- a/charts/dependabot-gitlab/README.md
+++ b/charts/dependabot-gitlab/README.md
@@ -40,6 +40,7 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | affinity | object | `{}` | Affinity |
 | createProjectsJob.activeDeadlineSeconds | int | `30` | Job Active Deadline |
 | createProjectsJob.backoffLimit | int | `2` | Job Backoff Limit |
+| createProjectsJob.securityContext | object | `{ runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }` | Job container security context definitions |
 | credentials.github_access_token | string | `""` | Github access token |
 | credentials.gitlab_access_token | string | `""` | Gitlab access token, required |
 | credentials.gitlab_auth_token | string | `""` | Gitlab auth token for webhook authentication |
@@ -98,6 +99,7 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | web.livenessProbe.timeoutSeconds | int | `1` | Liveness probe timeout |
 | web.replicaCount | int | `1` | Web container replicas count |
 | web.resources | object | `{}` | Web container resource definitions |
+| web.securityContext | object | `{ runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }` | Web container security context definitions |
 | web.startupProbe.enabled | bool | `true` | Enable startup probe |
 | web.startupProbe.failureThreshold | int | `12` | Startup probe failure threshold |
 | web.startupProbe.initialDelaySeconds | int | `10` | Startup probe initial delay |
@@ -109,6 +111,7 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | worker.livenessProbe.timeoutSeconds | int | `3` | Liveness probe timeout |
 | worker.replicaCount | int | `1` | Worker container replicas count |
 | worker.resources | object | `{}` | Worker container resource definitions |
+| worker.securityContext | object | `{ runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }` | Worker container security context definitions |
 | worker.startupProbe.enabled | bool | `true` | Enable startup probe |
 | worker.startupProbe.failureThreshold | int | `12` | Startup probe failure threshold |
 | worker.startupProbe.initialDelaySeconds | int | `10` | Startup probe initial delay |

--- a/charts/dependabot-gitlab/README.md
+++ b/charts/dependabot-gitlab/README.md
@@ -40,7 +40,6 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | affinity | object | `{}` | Affinity |
 | createProjectsJob.activeDeadlineSeconds | int | `30` | Job Active Deadline |
 | createProjectsJob.backoffLimit | int | `2` | Job Backoff Limit |
-| createProjectsJob.securityContext | object | `{ runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }` | Job container security context definitions |
 | credentials.github_access_token | string | `""` | Github access token |
 | credentials.gitlab_access_token | string | `""` | Gitlab access token, required |
 | credentials.gitlab_auth_token | string | `""` | Gitlab auth token for webhook authentication |
@@ -86,6 +85,7 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | redis.enabled | bool | `true` | Enable redis installation |
 | redis.fullnameOverride | string | `"redis"` | Override redis name |
 | registriesCredentials | object | `{}` | Credentials for private registries: PRIVATE_DOCKERHUB_TOKEN: token |
+| securityContext | object | `{ runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }` | Security context definitions for all started containers|
 | service.annotations | object | `{}` | Service annotations |
 | service.port | int | `3000` | Service pot |
 | service.type | string | `"ClusterIP"` | Service type |
@@ -99,7 +99,6 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | web.livenessProbe.timeoutSeconds | int | `1` | Liveness probe timeout |
 | web.replicaCount | int | `1` | Web container replicas count |
 | web.resources | object | `{}` | Web container resource definitions |
-| web.securityContext | object | `{ runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }` | Web container security context definitions |
 | web.startupProbe.enabled | bool | `true` | Enable startup probe |
 | web.startupProbe.failureThreshold | int | `12` | Startup probe failure threshold |
 | web.startupProbe.initialDelaySeconds | int | `10` | Startup probe initial delay |
@@ -111,7 +110,6 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | worker.livenessProbe.timeoutSeconds | int | `3` | Liveness probe timeout |
 | worker.replicaCount | int | `1` | Worker container replicas count |
 | worker.resources | object | `{}` | Worker container resource definitions |
-| worker.securityContext | object | `{ runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }` | Worker container security context definitions |
 | worker.startupProbe.enabled | bool | `true` | Enable startup probe |
 | worker.startupProbe.failureThreshold | int | `12` | Startup probe failure threshold |
 | worker.startupProbe.initialDelaySeconds | int | `10` | Startup probe initial delay |

--- a/charts/dependabot-gitlab/templates/_helpers.tpl
+++ b/charts/dependabot-gitlab/templates/_helpers.tpl
@@ -115,15 +115,6 @@ imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{- end }}
 
 {{/*
-Security context
-*/}}
-{{- define "dependabot-gitlab.securityContext" -}}
-runAsUser: 1000
-runAsGroup: 1000
-fsGroup: 1000
-{{- end }}
-
-{{/*
 Secrets credentials
 */}}
 {{- define "dependabot-gitlab.credentials" -}}

--- a/charts/dependabot-gitlab/templates/deployment-web.yaml
+++ b/charts/dependabot-gitlab/templates/deployment-web.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       serviceAccountName: {{ include "dependabot-gitlab.serviceAccountName" . }}
       securityContext:
-        {{- include "dependabot-gitlab.securityContext" . | nindent 8 }}
+        {{- toYaml .Values.web.securityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-web
           {{- include "dependabot-gitlab.image" . | nindent 10 }}

--- a/charts/dependabot-gitlab/templates/deployment-web.yaml
+++ b/charts/dependabot-gitlab/templates/deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "dependabot-gitlab.podAnnotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "dependabot-gitlab.serviceAccountName" . }}
-      {{- with .Values.securityContext }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dependabot-gitlab/templates/deployment-web.yaml
+++ b/charts/dependabot-gitlab/templates/deployment-web.yaml
@@ -19,8 +19,10 @@ spec:
         {{- include "dependabot-gitlab.podAnnotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "dependabot-gitlab.serviceAccountName" . }}
+      {{- with .Values.securityContext }}
       securityContext:
-        {{- toYaml .Values.web.securityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-web
           {{- include "dependabot-gitlab.image" . | nindent 10 }}

--- a/charts/dependabot-gitlab/templates/deployment-worker.yaml
+++ b/charts/dependabot-gitlab/templates/deployment-worker.yaml
@@ -19,8 +19,10 @@ spec:
         {{- include "dependabot-gitlab.podAnnotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "dependabot-gitlab.serviceAccountName" . }}
+      {{- with .Values.securityContext }}
       securityContext:
-        {{- toYaml .Values.worker.securityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-worker
           {{- include "dependabot-gitlab.image" . | nindent 10 }}

--- a/charts/dependabot-gitlab/templates/deployment-worker.yaml
+++ b/charts/dependabot-gitlab/templates/deployment-worker.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       serviceAccountName: {{ include "dependabot-gitlab.serviceAccountName" . }}
       securityContext:
-        {{- include "dependabot-gitlab.securityContext" . | nindent 8 }}
+        {{- toYaml .Values.worker.securityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-worker
           {{- include "dependabot-gitlab.image" . | nindent 10 }}

--- a/charts/dependabot-gitlab/templates/deployment-worker.yaml
+++ b/charts/dependabot-gitlab/templates/deployment-worker.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "dependabot-gitlab.podAnnotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "dependabot-gitlab.serviceAccountName" . }}
-      {{- with .Values.securityContext }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dependabot-gitlab/templates/job.yaml
+++ b/charts/dependabot-gitlab/templates/job.yaml
@@ -12,8 +12,10 @@ spec:
   activeDeadlineSeconds: {{ .Values.createProjectsJob.activeDeadlineSeconds }}
   template:
     spec:
+      {{- with .Values.securityContext }}
       securityContext:
-        {{- toYaml .Values.createProjectsJob.securityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-job
           {{- include "dependabot-gitlab.image" . | nindent 10 }}

--- a/charts/dependabot-gitlab/templates/job.yaml
+++ b/charts/dependabot-gitlab/templates/job.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     spec:
       securityContext:
-        {{- include "dependabot-gitlab.securityContext" . | nindent 8 }}
+        {{- toYaml .Values.createProjectsJob.securityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-job
           {{- include "dependabot-gitlab.image" . | nindent 10 }}

--- a/charts/dependabot-gitlab/templates/job.yaml
+++ b/charts/dependabot-gitlab/templates/job.yaml
@@ -12,7 +12,7 @@ spec:
   activeDeadlineSeconds: {{ .Values.createProjectsJob.activeDeadlineSeconds }}
   template:
     spec:
-      {{- with .Values.securityContext }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dependabot-gitlab/values.yaml
+++ b/charts/dependabot-gitlab/values.yaml
@@ -72,6 +72,10 @@ web:
     periodSeconds: 10
     # -- Startup probe timeout
     timeoutSeconds: 3
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
 
 worker:
   # -- Worker container replicas count
@@ -98,12 +102,20 @@ worker:
     periodSeconds: 5
     # -- Startup probe timeout
     timeoutSeconds: 3
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
 
 createProjectsJob:
   # -- Job Backoff Limit
   backoffLimit: 2
   # -- Job Active Deadline
   activeDeadlineSeconds: 30
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
 
 env:
   # -- Redis URL

--- a/charts/dependabot-gitlab/values.yaml
+++ b/charts/dependabot-gitlab/values.yaml
@@ -48,7 +48,7 @@ tolerations: []
 affinity: {}
 
 # -- Security Context
-securityContext:
+podSecurityContext:
   runAsUser: 1000
   runAsGroup: 1000
   fsGroup: 1000

--- a/charts/dependabot-gitlab/values.yaml
+++ b/charts/dependabot-gitlab/values.yaml
@@ -47,6 +47,12 @@ tolerations: []
 # -- Affinity
 affinity: {}
 
+# -- Security Context
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
 web:
   # -- Web container replicas count
   replicaCount: 1
@@ -72,10 +78,6 @@ web:
     periodSeconds: 10
     # -- Startup probe timeout
     timeoutSeconds: 3
-  securityContext:
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
 
 worker:
   # -- Worker container replicas count
@@ -102,20 +104,12 @@ worker:
     periodSeconds: 5
     # -- Startup probe timeout
     timeoutSeconds: 3
-  securityContext:
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
 
 createProjectsJob:
   # -- Job Backoff Limit
   backoffLimit: 2
   # -- Job Active Deadline
   activeDeadlineSeconds: 30
-  securityContext:
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
 
 env:
   # -- Redis URL


### PR DESCRIPTION
This PR enables consumers of the dependabot-gitlab chart to specify their own `securityContext` object for all containers (possibly) created by the chart. For example, this is necessary for deploying on the RedHat OpenShift Container Platform.

The changes introduced were tested on an OpenShift cluster, both using the default values and setting the `securityContext` to `{}` succeeded.