### PR TITLE
Add upstream proxy configuration

### DIFF
--- a/charts/dependabot-gitlab/Chart.yaml
+++ b/charts/dependabot-gitlab/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: dependabot-gitlab
 description: Deployment chart for dependabot-gitlab app
 type: application
-version: 0.0.85
+version: 0.0.86
 appVersion: 0.9.7
 icon: https://gitlab.com/dependabot-gitlab/dependabot/-/raw/master/logo.png
 maintainers:

--- a/charts/dependabot-gitlab/README.md
+++ b/charts/dependabot-gitlab/README.md
@@ -1,6 +1,6 @@
 # dependabot-gitlab
 
-![Version: 0.0.85](https://img.shields.io/badge/Version-0.0.85-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.7](https://img.shields.io/badge/AppVersion-0.9.7-informational?style=flat-square)
+![Version: 0.0.86](https://img.shields.io/badge/Version-0.0.86-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.7](https://img.shields.io/badge/AppVersion-0.9.7-informational?style=flat-square)
 
 [dependabot-gitlab](https://gitlab.com/dependabot-gitlab/dependabot) is application providing automated dependency management for gitlab projects
 
@@ -47,9 +47,12 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | env.commandsPrefix | string | `""` | Dependabot comment command prefix |
 | env.dependabotUrl | string | `""` | Optional app url, used for automated webhook creation |
 | env.gitlabUrl | string | `"https://gitlab.com"` | Gitlab instance URL |
+| env.http_proxy | string | `""` | Enable upstream http proxy |
+| env.https_proxy | string | `""` | Enable upstream https proxy |
 | env.metrics | bool | `true` | Enable metrics endpoint for prometheus |
 | env.mongoDbUri | string | `""` | MongoDB URI |
 | env.mongoDbUrl | string | `""` | MongoDB URL |
+| env.no_proxy | string | `""` | Set proxy exceptions |
 | env.redisUrl | string | `""` | Redis URL |
 | env.sentryDsn | string | `""` | Optional sentry dsn for error reporting |
 | env.updateRetry | int | `2` | Update job retry count or 'false' to disable |

--- a/charts/dependabot-gitlab/templates/configmap.yaml
+++ b/charts/dependabot-gitlab/templates/configmap.yaml
@@ -41,3 +41,12 @@ data:
   {{- else if not .Values.env.mongoDbUri }}
   MONGODB_URL: {{ required "mongodbUrl must be provided" .Values.env.mongoDbUrl | quote }}
   {{- end }}
+  {{- if .Values.env.http_proxy }}
+  http_proxy: {{ .Values.env.http_proxy }}
+  {{- end }}
+  {{- if .Values.env.https_proxy }}
+  https_proxy: {{ .Values.env.https_proxy }}
+  {{- end }}
+  {{- if .Values.env.no_proxy }}
+  no_proxy: {{ .Values.env.no_proxy }}
+  {{- end }}

--- a/charts/dependabot-gitlab/values.yaml
+++ b/charts/dependabot-gitlab/values.yaml
@@ -144,6 +144,10 @@ env:
   updateRetry: 2
   # -- Enable metrics endpoint for prometheus
   metrics: true
+  # -- Enable upstream http proxy
+  https_proxy: ""
+  http_proxy: ""
+  no_proxy: ""
 
 credentials:
   # -- Gitlab access token, required

--- a/charts/dependabot-gitlab/values.yaml
+++ b/charts/dependabot-gitlab/values.yaml
@@ -144,9 +144,11 @@ env:
   updateRetry: 2
   # -- Enable metrics endpoint for prometheus
   metrics: true
-  # -- Enable upstream http proxy
+  # -- Enable upstream https proxy
   https_proxy: ""
+  # -- Enable upstream http proxy
   http_proxy: ""
+  # -- Set proxy exceptions
   no_proxy: ""
 
 credentials:


### PR DESCRIPTION
In organisations with an internal gitlab, github can't be fetched without use an http proxy.

This MR add some values to support upstream proxy support.

I use the same approch as for the other env params, but feel free to give any feedback.
