### PR TITLE
Support separate configurations for web and worker pods

### DIFF
--- a/charts/dependabot-gitlab/README.md
+++ b/charts/dependabot-gitlab/README.md
@@ -37,7 +37,6 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` | Affinity |
 | createProjectsJob.activeDeadlineSeconds | int | `240` | Job Active Deadline |
 | createProjectsJob.resources | object | `{}` | Create projects job resource definitions |
 | credentials.github_access_token | string | `""` | Github access token |
@@ -93,8 +92,6 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | mongodb.fullnameOverride | string | `"mongodb"` | String to fully override mongodb.fullname template |
 | mongodb.service.port | int | `27017` | Mongodb service port |
 | nameOverride | string | `""` | Override chart name |
-| nodeSelector | object | `{}` | Node selectors |
-| podAnnotations | object | `{}` | Pod annotations |
 | podSecurityContext | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsUser":1000}` | Security Context |
 | project_registration.cron | string | `""` | Cron expression of project registration cron job |
 | project_registration.mode | string | `"manual"` | Project registration mode |
@@ -112,11 +109,13 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount.annotations | object | `{}` | Service account annotations |
 | serviceAccount.name | string | `""` | Service account name |
-| tolerations | list | `[]` | Tolerations |
+| web.affinity | object | `{}` | Affinity |
 | web.livenessProbe.enabled | bool | `true` | Enable liveness probe |
 | web.livenessProbe.failureThreshold | int | `5` | Liveness probe failure threshold |
 | web.livenessProbe.periodSeconds | int | `10` | Liveness probe period |
 | web.livenessProbe.timeoutSeconds | int | `2` | Liveness probe timeout |
+| web.nodeSelector | object | `{}` | Node selectors |
+| web.podAnnotations | object | `{}` | Pod annotations |
 | web.replicaCount | int | `1` | Web container replicas count |
 | web.resources | object | `{}` | Web container resource definitions |
 | web.startupProbe.enabled | bool | `true` | Enable startup probe |
@@ -124,11 +123,15 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | web.startupProbe.initialDelaySeconds | int | `10` | Startup probe initial delay |
 | web.startupProbe.periodSeconds | int | `10` | Startup probe period |
 | web.startupProbe.timeoutSeconds | int | `3` | Startup probe timeout |
+| web.tolerations | list | `[]` | Tolerations |
 | web.updateStrategy | object | `{"type":"RollingUpdate"}` | Set up strategy for web installation |
+| worker.affinity | object | `{}` | Affinity |
 | worker.livenessProbe.enabled | bool | `true` | Enable liveness probe |
 | worker.livenessProbe.failureThreshold | int | `2` | Liveness probe failure threshold |
 | worker.livenessProbe.periodSeconds | int | `120` | Liveness probe period |
 | worker.livenessProbe.timeoutSeconds | int | `3` | Liveness probe timeout |
+| worker.nodeSelector | object | `{}` | Node selectors |
+| worker.podAnnotations | object | `{}` | Pod annotations |
 | worker.probePort | int | `7433` | Health check probe port |
 | worker.replicaCount | int | `1` | Worker container replicas count |
 | worker.resources | object | `{}` | Worker container resource definitions |
@@ -137,4 +140,5 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | worker.startupProbe.initialDelaySeconds | int | `10` | Startup probe initial delay |
 | worker.startupProbe.periodSeconds | int | `5` | Startup probe period |
 | worker.startupProbe.timeoutSeconds | int | `3` | Startup probe timeout |
+| worker.tolerations | list | `[]` | Tolerations |
 | worker.updateStrategy | object | `{"type":"RollingUpdate"}` | Set up strategy for worker installation |

--- a/charts/dependabot-gitlab/templates/_helpers.tpl
+++ b/charts/dependabot-gitlab/templates/_helpers.tpl
@@ -63,9 +63,6 @@ checksum/redis-password: {{ default (randAlphaNum 10) .Values.redis.auth.passwor
 {{- if .Values.mongodb.auth.enabled }}
 checksum/mongodb-password: {{ default (randAlphaNum 10) .Values.mongodb.auth.password | sha256sum }}
 {{- end }}
-{{- with .Values.podAnnotations }}
-{{ toYaml . }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/dependabot-gitlab/templates/deployment-web.yaml
+++ b/charts/dependabot-gitlab/templates/deployment-web.yaml
@@ -18,6 +18,9 @@ spec:
         app.kubernetes.io/component: web
       annotations:
         {{- include "dependabot-gitlab.podAnnotations" . | nindent 8 }}
+        {{- with .Values.web.podAnnotations }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "dependabot-gitlab.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}
@@ -69,15 +72,15 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.web.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.web.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.web.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dependabot-gitlab/templates/deployment-worker.yaml
+++ b/charts/dependabot-gitlab/templates/deployment-worker.yaml
@@ -18,6 +18,9 @@ spec:
         app.kubernetes.io/component: worker
       annotations:
         {{- include "dependabot-gitlab.podAnnotations" . | nindent 8 }}
+        {{- with .Values.worker.podAnnotations }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "dependabot-gitlab.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}
@@ -93,15 +96,15 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       terminationGracePeriodSeconds: 300 # Large dependency files or docker images can take long time to process
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.worker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dependabot-gitlab/templates/migration-job.yaml
+++ b/charts/dependabot-gitlab/templates/migration-job.yaml
@@ -49,6 +49,18 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       restartPolicy: Never
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 6 }}

--- a/charts/dependabot-gitlab/templates/registration-job.yaml
+++ b/charts/dependabot-gitlab/templates/registration-job.yaml
@@ -41,6 +41,18 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       restartPolicy: Never
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 6 }}

--- a/charts/dependabot-gitlab/values.yaml
+++ b/charts/dependabot-gitlab/values.yaml
@@ -44,18 +44,6 @@ ingress:
       paths: []
   tls: []
 
-# -- Pod annotations
-podAnnotations: {}
-
-# -- Node selectors
-nodeSelector: {}
-
-# -- Tolerations
-tolerations: []
-
-# -- Affinity
-affinity: {}
-
 # -- Security Context
 podSecurityContext:
   runAsUser: 1000
@@ -85,6 +73,14 @@ metrics:
     honorLabels: false
 
 web:
+  # -- Pod annotations
+  podAnnotations: {}
+  # -- Node selectors
+  nodeSelector: {}
+  # -- Tolerations
+  tolerations: []
+  # -- Affinity
+  affinity: {}
   # -- Web container replicas count
   replicaCount: 1
   # -- Web container resource definitions
@@ -114,6 +110,14 @@ web:
     timeoutSeconds: 3
 
 worker:
+  # -- Pod annotations
+  podAnnotations: {}
+  # -- Node selectors
+  nodeSelector: {}
+  # -- Tolerations
+  tolerations: []
+  # -- Affinity
+  affinity: {}
   # -- Worker container replicas count
   replicaCount: 1
   # -- Worker container resource definitions


### PR DESCRIPTION
Move node selector, affinity, toleration and annotation configs to specific deployments:

Closes: https://github.com/andrcuns/charts/issues/96