### PR TITLE
Remove ttlSecondsAfterFinished for migration-job

### DIFF
--- a/charts/dependabot-gitlab/templates/migration-job.yaml
+++ b/charts/dependabot-gitlab/templates/migration-job.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "dependabot-gitlab.labels" . | nindent 4 }}
 spec:
-  ttlSecondsAfterFinished: 3600
   backoffLimit: {{ .Values.migrationJob.backoffLimit }}
   activeDeadlineSeconds: {{ .Values.migrationJob.activeDeadlineSeconds }}
   template:


### PR DESCRIPTION
This prevents a crash on container/pod restart due to `Error from server (NotFound): jobs.batch "dependabot-dependabot-gitlab-migration-job-0.10.6" not found`

This resolves #101 by reverting parts of #92.