### PR TITLE
feat: allow custom environment variable spec

### DIFF
--- a/charts/dependabot-gitlab/README.md
+++ b/charts/dependabot-gitlab/README.md
@@ -108,6 +108,7 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | serviceAccount.annotations | object | `{}` | Service account annotations |
 | serviceAccount.name | string | `""` | Service account name |
 | web.affinity | object | `{}` | Affinity |
+| web.extraEnvVars | object | `{}` |  |
 | web.extraVolumeMounts | string | `nil` |  |
 | web.extraVolumes | string | `nil` |  |
 | web.livenessProbe.enabled | bool | `true` | Enable liveness probe |
@@ -126,6 +127,7 @@ By default chart installs instance of [redis](https://github.com/bitnami/charts/
 | web.tolerations | list | `[]` | Tolerations |
 | web.updateStrategy | object | `{"type":"RollingUpdate"}` | Set up strategy for web installation |
 | worker.affinity | object | `{}` | Affinity |
+| worker.extraEnvVars | object | `{}` |  |
 | worker.extraVolumeMounts | string | `nil` |  |
 | worker.extraVolumes | string | `nil` |  |
 | worker.livenessProbe.enabled | bool | `true` | Enable liveness probe |

--- a/charts/dependabot-gitlab/templates/deployment-web.yaml
+++ b/charts/dependabot-gitlab/templates/deployment-web.yaml
@@ -36,10 +36,13 @@ spec:
           args:
             - "rails"
             - "server"
-          {{- with (include "dependabot-gitlab.database-credentials" .) }}
           env:
+          {{- with (include "dependabot-gitlab.database-credentials" .) }}
             {{- . | nindent 12 }}
           {{- end }}
+          {{- with .Values.web.extraEnvVars }}
+            {{- toYaml .Values.web.extraEnvVars | nindent 12 }}
+          {{- end}}
           envFrom:
             - configMapRef:
                 name: {{ include "dependabot-gitlab.fullname" . }}

--- a/charts/dependabot-gitlab/templates/deployment-worker.yaml
+++ b/charts/dependabot-gitlab/templates/deployment-worker.yaml
@@ -56,6 +56,9 @@ spec:
           {{- with (include "dependabot-gitlab.database-credentials" .) }}
             {{- . | nindent 12 }}
           {{- end }}
+          {{- with .Values.worker.extraEnvVars }}
+            {{- toYaml .Values.worker.extraEnvVars | nindent 12 }}
+          {{- end}}
           envFrom:
             - configMapRef:
                 name: {{ include "dependabot-gitlab.fullname" . }}

--- a/charts/dependabot-gitlab/values.yaml
+++ b/charts/dependabot-gitlab/values.yaml
@@ -103,6 +103,8 @@ web:
   extraVolumeMounts:
   # Extra volumes
   extraVolumes:
+  # Extra environment variables
+  extraEnvVars: {}
 
 worker:
   # -- Pod annotations
@@ -146,6 +148,8 @@ worker:
   extraVolumeMounts:
   # Extra volumes
   extraVolumes:
+  # Extra environment variables
+  extraEnvVars: {}
 
 createProjectsJob:
   # -- Job Back off limit


### PR DESCRIPTION
I noticed there is no way to set custom environment variables whereas, they can be used in the dependabot config files using `${{VARIABLE_NAME}}` if I understand the docs correctly. https://gitlab.com/dependabot-gitlab/dependabot/-/blob/master/doc/dependabot.md#registries

I've implemented this in the same way it is for bitnami charts.