### PR TITLE
Allow setting lifecycle hooks and terminationGracePeriodSeconds

### DIFF
--- a/charts/buildkit-service/README.md
+++ b/charts/buildkit-service/README.md
@@ -41,6 +41,7 @@ The command deploys buildkit-service on the Kubernetes cluster in the default co
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy |
 | image.repository | string | `"moby/buildkit"` | Image name |
 | image.tag | string | `""` | Image tag |
+| lifecycle | object | `{}` | Lifecycle hooks and termination |
 | nodeSelector | object | `{}` | Node selector |
 | pdb.minAvailable | int | `1` | Minimum available pods |
 | podAnnotations | object | `{}` | Pod annotations |
@@ -51,6 +52,7 @@ The command deploys buildkit-service on the Kubernetes cluster in the default co
 | service.loadbalancerIp | string | `""` | Static ip address for load balancer |
 | service.port | int | `1234` | Service port |
 | service.type | string | `"ClusterIP"` | Service type |
+| terminationGracePeriodSeconds | int | `30` |  |
 | tls.cert | string | `nil` | Base64 encoded cert.pem |
 | tls.certCA | string | `nil` | Base64 encoded ca.pem |
 | tls.certKey | string | `nil` | Base64 encoded key.pem |

--- a/charts/buildkit-service/templates/deployment.yaml
+++ b/charts/buildkit-service/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.lifecycle }
+          {{- with .Values.lifecycle }}
           lifecycle:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/buildkit-service/templates/deployment.yaml
+++ b/charts/buildkit-service/templates/deployment.yaml
@@ -93,6 +93,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.lifecycle }
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- if or .Values.rootless .Values.tls.enabled .Values.buildkitdToml }}
       volumes:
       {{- if .Values.buildkitdToml }}
@@ -122,3 +126,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}

--- a/charts/buildkit-service/values.yaml
+++ b/charts/buildkit-service/values.yaml
@@ -72,3 +72,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # -- Target memory utilization percentage
   targetMemoryUtilizationPercentage: 80
+
+# -- Lifecycle hooks and termination
+lifecycle: {}
+terminationGracePeriodSeconds: 30


### PR DESCRIPTION
This PR allows users to set custom `lifecycle` hooks and their own `terminationGracePeriodSeconds` timeout for buildkit pods.

## But Why?

Whenever a buildkit pod needs to be terminated, [Kubernetes will send it a `SIGTERM` signal](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-terminating-with-grace). Applications are _supposed to_ use this to finish their work and shut down gracefully. Unfortunately, [buildkit immediately stops its server, causing ongoing builds to fail](https://github.com/moby/buildkit/issues/4090) instead of waiting for those builds to complete.

To work around this, I'd like to configure my buildkit container with [a PreStop hook](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) that waits for the builds to complete.  A naive solution would simply simply sleep for a few minutes; a more complex solution could be a script that monitors the container's processes and waits until it sees no activity.  Either way, I'll also need to bump `terminationGracePeriodSeconds` from it's default of 30 seconds to ensure the builds have enough time to complete before the `SIGTERM` is sent.

Being able to specify the `lifecycle` hook and `terminationGracePeriodSeconds` will help me achieve this.