### PR TITLE
Repair indent error in volumes list.

### DIFF
--- a/charts/buildkit-service/templates/deployment.yaml
+++ b/charts/buildkit-service/templates/deployment.yaml
@@ -100,9 +100,9 @@ spec:
       {{- if or .Values.rootless .Values.tls.enabled .Values.buildkitdToml }}
       volumes:
       {{- if .Values.buildkitdToml }}
-        - name: config
-          configMap:
-            name: buildkitd-config
+      - name: config
+        configMap:
+          name: buildkitd-config
       {{- end }}
       {{- if .Values.rootless }}
       - name: buildkitd


### PR DESCRIPTION
There is an indentation error in the buildkit deployment.yaml triggering an error when rootless and buildkitdToml values are both in the template values.

This pull repairs the erroneous indentation of the buildkitToml volume specification.