### PR TITLE
Fix buildkitd.toml mountPath when rootless

### DIFF
--- a/charts/buildkit-service/templates/deployment.yaml
+++ b/charts/buildkit-service/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           volumeMounts:
           {{- if .Values.buildkitdToml }}
             - name: config
-              mountPath: /etc/buildkit
+              mountPath: {{ if .Values.rootless }}/home/user/.config/buildkit{{ else }}/etc/buildkit{{ end }}
           {{- end }}
           {{- if .Values.tls.enabled }}
             - name: certs


### PR DESCRIPTION
Hi @andrcuns,

When the deploy/container is rootless, seems that the mountPath of buildkitd.toml is other than /etc/buildkit.

Official doc: https://docs.docker.com/build/buildkit/toml-configuration