### PR TITLE
Feat: add daemon args

### DIFF
--- a/charts/buildkit-service/README.md
+++ b/charts/buildkit-service/README.md
@@ -44,8 +44,8 @@ The command deploys buildkit-service on the Kubernetes cluster in the default co
 | buildkitVolume.pvc.storageClassName | string | `""` | Storage class name |
 | buildkitVolume.type | string | `"emptyDir"` | Volume type: 'emptyDir' or 'pvc' |
 | buildkitdToml | string | `""` | Custom configuration buildkitd.toml |
-| debugLog | bool | `false` | Enable debug logging |
 | daemonArgs | list | `[]` | Buildkitd command line parameters |
+| debugLog | bool | `false` | Enable debug logging |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy |
 | image.repository | string | `"moby/buildkit"` | Image name |
 | image.tag | string | `""` | Image tag |

--- a/charts/buildkit-service/README.md
+++ b/charts/buildkit-service/README.md
@@ -45,6 +45,7 @@ The command deploys buildkit-service on the Kubernetes cluster in the default co
 | buildkitVolume.type | string | `"emptyDir"` | Volume type: 'emptyDir' or 'pvc' |
 | buildkitdToml | string | `""` | Custom configuration buildkitd.toml |
 | debugLog | bool | `false` | Enable debug logging |
+| daemonArgs | list | `[]` | Buildkitd command line parameters |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy |
 | image.repository | string | `"moby/buildkit"` | Image name |
 | image.tag | string | `""` | Image tag |

--- a/charts/buildkit-service/templates/deployment.yaml
+++ b/charts/buildkit-service/templates/deployment.yaml
@@ -70,6 +70,9 @@ spec:
           {{- if .Values.debugLog }}
             - --debug
           {{- end }}
+          {{- range .Values.daemonArgs }}
+            - {{ . }}
+          {{- end }}
           ports:
             - name: tcp
               containerPort: 1234

--- a/charts/buildkit-service/values.yaml
+++ b/charts/buildkit-service/values.yaml
@@ -17,6 +17,9 @@ preStop: false
 # -- Enable debug logging
 debugLog: false
 
+# -- Buildkitd command line parameters
+daemonArgs: []
+
 pdb:
   # -- Minimum available pods
   minAvailable: 1


### PR DESCRIPTION
This allows to further customize the buildkitd command line. 

The motivation at this time is to use tools such as the ones described here: 
https://github.com/moby/buildkit/blob/master/.github/issue_reporting_guide.md#reporting-deadlock

Solves https://github.com/andrcuns/charts/issues/319