### PR TITLE
Support providing TLS certificates from an existing Secret

### DIFF
--- a/charts/buildkit-service/README.md
+++ b/charts/buildkit-service/README.md
@@ -66,4 +66,5 @@ The command deploys buildkit-service on the Kubernetes cluster in the default co
 | tls.certCA | string | `nil` | Base64 encoded ca.pem |
 | tls.certKey | string | `nil` | Base64 encoded key.pem |
 | tls.enabled | bool | `false` | Enable mTLS, refer to https://github.com/moby/buildkit/tree/master/examples/kubernetes#deployment--service |
+| tls.existingSecret | string | `nil` | Name of an existing Secret in this namespace containing the certificate to be used for the server half of mTLS. Expected to contain tls.crt, tls.key ,ca.crt. |
 | tolerations | list | `[]` | Tolerations |

--- a/charts/buildkit-service/templates/_helpers.tpl
+++ b/charts/buildkit-service/templates/_helpers.tpl
@@ -61,19 +61,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Return the path to the cert file.
 */}}
 {{- define "buildkit.tlsCert" -}}
-{{- required "Certificate is required when TLS in enabled" .Values.tls.cert -}}
+{{- required "Certificate is required when TLS in enabled and no existing Secret is provided" .Values.tls.cert -}}
 {{- end -}}
 
 {{/*
 Return the path to the cert key file.
 */}}
 {{- define "buildkit.tlsCertKey" -}}
-{{- required "Certificate Key is required when TLS in enabled" .Values.tls.certKey -}}
+{{- required "Certificate Key is required when TLS in enabled and no existing Secret is provided" .Values.tls.certKey -}}
 {{- end -}}
 
 {{/*
 Return the path to the CA cert file.
 */}}
 {{- define "buildkit.tlsCertCACert" -}}
-{{- required "Certificate CA is required when TLS in enabled" .Values.tls.certCA -}}
+{{- required "Certificate CA is required when TLS in enabled and no existing Secret is provided" .Values.tls.certCA -}}
 {{- end -}}

--- a/charts/buildkit-service/templates/deployment.yaml
+++ b/charts/buildkit-service/templates/deployment.yaml
@@ -134,7 +134,7 @@ spec:
       {{- if .Values.tls.enabled }}
       - name: certs
         secret:
-          secretName: {{ include "buildkit.fullname" . }}
+          secretName: {{ .Values.tls.existingSecret | default (include "buildkit.fullname" .) }}
       {{- end }}
       {{- if .Values.preStop }}
       - name: files

--- a/charts/buildkit-service/templates/secret.yaml
+++ b/charts/buildkit-service/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tls.enabled }}
+{{- if and .Values.tls.enabled (not .Values.tls.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/buildkit-service/values.yaml
+++ b/charts/buildkit-service/values.yaml
@@ -63,6 +63,8 @@ tls:
   certKey:
   # -- Base64 encoded ca.pem
   certCA:
+  # -- Name of an existing Secret in this namespace containing the certificate to be used for the server half of mTLS. Expected to contain tls.crt, tls.key ,ca.crt.
+  existingSecret:
 
 # -- Custom configuration buildkitd.toml
 buildkitdToml: ""


### PR DESCRIPTION
i.e. so that credentials don't need to be embedded in Helm values and / or something like Vault Secrets Operator or cert-manager can be used for certificate generation.