### PR TITLE
add an option to pass env vars to the buildkit pod

### DIFF
--- a/charts/buildkit-service/README.md
+++ b/charts/buildkit-service/README.md
@@ -46,6 +46,7 @@ The command deploys buildkit-service on the Kubernetes cluster in the default co
 | buildkitdToml | string | `""` | Custom configuration buildkitd.toml |
 | daemonArgs | list | `[]` | Buildkitd command line parameters |
 | debugLog | bool | `false` | Enable debug logging |
+| env | list | `[]` | Environment variables for the buildkit container |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy |
 | image.repository | string | `"moby/buildkit"` | Image name |
 | image.tag | string | `""` | Image tag |

--- a/charts/buildkit-service/templates/deployment.yaml
+++ b/charts/buildkit-service/templates/deployment.yaml
@@ -47,6 +47,10 @@ spec:
             mountPath: /usr/local/bin/buildkit-prestop.sh
             subPath: buildkit-prestop.sh
           {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.preStop }}
           lifecycle:
             preStop:

--- a/charts/buildkit-service/values.yaml
+++ b/charts/buildkit-service/values.yaml
@@ -20,6 +20,13 @@ debugLog: false
 # -- Buildkitd command line parameters
 daemonArgs: []
 
+# -- Environment variables for the buildkit container
+env: []
+  # - name: HTTP_PROXY
+  #   value: "http://proxy.example.com:8080"
+  # - name: BUILDKIT_STEP_LOG_MAX_SIZE
+  #   value: "10485760"
+
 pdb:
   # -- Minimum available pods
   minAvailable: 1


### PR DESCRIPTION
Add an option to pass env vars to the buildkit pod