### PR TITLE
Add serviceAccountName support to buildkit-service chart

### DIFF
--- a/charts/buildkit-service/README.md
+++ b/charts/buildkit-service/README.md
@@ -68,6 +68,7 @@ The command deploys buildkit-service on the Kubernetes cluster in the default co
 | service.loadbalancerIp | string | `""` | Static ip address for load balancer |
 | service.port | int | `1234` | Service port |
 | service.type | string | `"ClusterIP"` | Service type |
+| serviceAccountName | string | `"default"` | Service account name for the pod |
 | terminationGracePeriodSeconds | int | `30` |  |
 | tls.cert | string | `nil` | Base64 encoded cert.pem |
 | tls.certCA | string | `nil` | Base64 encoded ca.pem |

--- a/charts/buildkit-service/ci/ci-default-values.yaml
+++ b/charts/buildkit-service/ci/ci-default-values.yaml
@@ -2,3 +2,4 @@ rootless: false
 tls:
   enabled: false
 preStop: true
+serviceAccountName: "default"

--- a/charts/buildkit-service/ci/ci-service-account-values.yaml
+++ b/charts/buildkit-service/ci/ci-service-account-values.yaml
@@ -1,1 +1,1 @@
-serviceAccountName: "custom-sa"
+serviceAccountName: "default"

--- a/charts/buildkit-service/ci/ci-service-account-values.yaml
+++ b/charts/buildkit-service/ci/ci-service-account-values.yaml
@@ -1,1 +1,0 @@
-serviceAccountName: "default"

--- a/charts/buildkit-service/ci/ci-service-account-values.yaml
+++ b/charts/buildkit-service/ci/ci-service-account-values.yaml
@@ -1,0 +1,1 @@
+serviceAccountName: "custom-sa"

--- a/charts/buildkit-service/templates/deployment.yaml
+++ b/charts/buildkit-service/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         {{- include "buildkit.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ .Values.serviceAccountName }}
       {{- with .Values.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/charts/buildkit-service/values.yaml
+++ b/charts/buildkit-service/values.yaml
@@ -135,6 +135,9 @@ initContainers: []
   #       add: ["NET_ADMIN"]
   #     runAsUser: 0
 
+# -- Service account name for the pod
+serviceAccountName: "default"
+
 # -- Lifecycle hooks and termination
 lifecycle: {}
 terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## Summary

- Add `serviceAccountName` value to the buildkit-service chart (defaults to `"default"`)
- Reference it in the deployment template under `spec.template.spec.serviceAccountName`
- Add CI test values file for the new field

This enables use cases like AWS IRSA or GCP Workload Identity where BuildKit pods need a specific service account to access private container registries or registry mirrors.

Closes #393