### PR TITLE
feat(buildkit-service): configurable liveness/readiness probe parameters

### DIFF
--- a/charts/buildkit-service/README.md
+++ b/charts/buildkit-service/README.md
@@ -57,10 +57,12 @@ The command deploys buildkit-service on the Kubernetes cluster in the default co
 | image.tag | string | `""` | Image tag |
 | initContainers | list | `[]` | Init containers to run before the main buildkit container Useful for network configuration, volume preparation, etc. |
 | lifecycle | object | `{}` | Lifecycle hooks and termination |
+| livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":30,"timeoutSeconds":1}` | Liveness probe configuration |
 | nodeSelector | object | `{}` | Node selector |
 | pdb.minAvailable | int | `1` | Minimum available pods |
 | podAnnotations | object | `{}` | Pod annotations |
 | preStop | bool | `false` | Enable the preStop script for graceful shutdown, https://github.com/seatgeek/buildkit-prestop-script |
+| readinessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":30,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe configuration |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` | Resource definitions |
 | rootless | bool | `false` | Run rootless mode, https://github.com/moby/buildkit/blob/master/docs/rootless.md |

--- a/charts/buildkit-service/templates/deployment.yaml
+++ b/charts/buildkit-service/templates/deployment.yaml
@@ -102,16 +102,21 @@ spec:
               - buildctl
               - debug
               - workers
-            initialDelaySeconds: 5
-            periodSeconds: 30
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
           livenessProbe:
             exec:
               command:
               - buildctl
               - debug
               - workers
-            initialDelaySeconds: 5
-            periodSeconds: 30
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           securityContext:
           {{- if .Values.rootless }}
             {{- if semverCompare ">=1.30.0" .Capabilities.KubeVersion.Version }}

--- a/charts/buildkit-service/values.yaml
+++ b/charts/buildkit-service/values.yaml
@@ -43,6 +43,21 @@ service:
   # -- Service annotations
   annotations: {}
 
+# -- Liveness probe configuration
+livenessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 30
+  timeoutSeconds: 1
+  failureThreshold: 3
+
+# -- Readiness probe configuration
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 30
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+
 # -- Resource definitions
 resources: {}
   # limits:


### PR DESCRIPTION
Add values for controlling liveness and readiness probe parameters
(initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold,
successThreshold) instead of hardcoded defaults.

Defaults are kept identical to the previous hardcoded values,
so existing deployments are unaffected without explicit overrides.